### PR TITLE
#12 + #14:  fix sobering up message + better special abilities, including the Orbs of Disorder 🔵🔵

### DIFF
--- a/character.py
+++ b/character.py
@@ -19,7 +19,9 @@ class Character:
         self._set_reactions()
         self._set_special_abilities()
 
-    def _set_attr_from_file(self, attr, filepath, strip=False, allow_empty=False, empty_val=None):
+    def _set_attr_from_file(
+        self, attr, filepath, strip=False, allow_empty=False, empty_val=None
+    ):
         """
         Read and set character data from a file, and set the character attribute
         to empty_val if file does not exist.
@@ -31,11 +33,11 @@ class Character:
         """
         if os.path.exists(filepath):
             with open(filepath, "r") as attr_fl:
-                if filepath.endswith('txt'):
+                if filepath.endswith("txt"):
                     val = attr_fl.read()
                     if strip:
                         val = val.strip()
-                elif filepath.endswith('json'):
+                elif filepath.endswith("json"):
                     val = json.load(attr_fl)
                 else:
                     raise ValueError(f"Unsupported filetype at the moment: {filepath}")
@@ -43,7 +45,9 @@ class Character:
         elif allow_empty:
             setattr(self, attr, empty_val)
         else:
-            raise FileNotFoundError(f"Could not set {attr}! Expected file not found: {filepath}")
+            raise FileNotFoundError(
+                f"Could not set {attr}! Expected file not found: {filepath}"
+            )
 
     def _set_bio(self):
         self._set_attr_from_file(
@@ -58,7 +62,7 @@ class Character:
             filepath=f"{self.namepath}/ascii_art.txt",
             strip=True,
             allow_empty=True,
-            empty_val=""
+            empty_val="",
         )
 
     def _set_magic_info(self):
@@ -78,7 +82,7 @@ class Character:
             attr="reactions",
             filepath=f"{self.namepath}/reactions.json",
             allow_empty=True,
-            empty_val=None
+            empty_val=None,
         )
 
     def _set_special_abilities(self, special_path=None):
@@ -86,7 +90,7 @@ class Character:
             attr="special_abilities_info",
             filepath=f"{self.namepath}/special.json",
             allow_empty=True,
-            empty_val={}
+            empty_val={},
         )
 
     def print_life(self):
@@ -127,8 +131,6 @@ class Character:
                 return
 
             ability = SpecialAbility(
-                player=self,
-                opponent=opponent,
-                effect=random.choice(abilities)
+                player=self, opponent=opponent, effect=random.choice(abilities)
             )
             return ability.perform()

--- a/character.py
+++ b/character.py
@@ -88,7 +88,7 @@ class Character:
     def _set_special_abilities(self, special_path=None):
         self._set_attr_from_file(
             attr="special_abilities_info",
-            filepath=f"{self.namepath}/special.json",
+            filepath=special_path or f"{self.namepath}/special.json",
             allow_empty=True,
             empty_val={},
         )

--- a/character.py
+++ b/character.py
@@ -89,6 +89,9 @@ class Character:
             empty_val={}
         )
 
+    def print_life(self):
+        print(f'{self.name}: {"+"*self.life}({self.life} sparks left)')
+
     def possibly_taunt(self):
         """Depending on their percent chance of doing so (some characters
         are nicer), pick and say a random taunt.
@@ -107,7 +110,7 @@ class Character:
             )
             time.sleep(1)
 
-    def possibly_activate_special_ability(self, chance):
+    def possibly_activate_special_ability(self, chance, opponent):
         """Depending on percent chance, possibly auto-activiate a special ability.
 
         Definitely meant for computer opponents at the moment.
@@ -115,16 +118,17 @@ class Character:
         Chance is hard-coded for this now because I am sad.
         """
         if did_it_happen(chance):
-            import special_abilities
+            from special_abilities import SpecialAbility
 
             abilities = [
-                ability["effect"] for ability in self.special_abilities_info.values()
+                info["effect"] for info in self.special_abilities_info.values()
             ]
-
             if not abilities:
                 return
 
-            ability = random.choice(abilities)
-            ability_func = getattr(special_abilities, ability)
-
-            return ability_func(self)
+            ability = SpecialAbility(
+                player=self,
+                opponent=opponent,
+                effect=random.choice(abilities)
+            )
+            return ability.perform()

--- a/character.py
+++ b/character.py
@@ -117,20 +117,23 @@ class Character:
     def possibly_activate_special_ability(self, chance, opponent):
         """Depending on percent chance, possibly auto-activiate a special ability.
 
-        Definitely meant for computer opponents at the moment.
+        Definitely meant for the non-human contender the moment.
 
         Chance is hard-coded for this now because I am sad.
         """
-        if did_it_happen(chance):
-            from special_abilities import SpecialAbility
+        if not did_it_happen(chance):
+            return self, opponent
 
-            abilities = [
-                info["effect"] for info in self.special_abilities_info.values()
-            ]
-            if not abilities:
-                return
+        from special_abilities import SpecialAbility
 
-            ability = SpecialAbility(
-                player=self, opponent=opponent, effect=random.choice(abilities)
-            )
-            return ability.perform()
+        abilities = [
+            info["effect"] for info in self.special_abilities_info.values()
+        ]
+        if not abilities:
+            # why am i doing this. what is life?
+            return self, opponent
+
+        ability = SpecialAbility(
+            player=self, opponent=opponent, effect=random.choice(abilities)
+        )
+        return ability.perform()

--- a/character.py
+++ b/character.py
@@ -126,9 +126,7 @@ class Character:
 
         from special_abilities import SpecialAbility
 
-        abilities = [
-            info["effect"] for info in self.special_abilities_info.values()
-        ]
+        abilities = [info["effect"] for info in self.special_abilities_info.values()]
         if not abilities:
             # why am i doing this. what is life?
             return self, human_opponent

--- a/character.py
+++ b/character.py
@@ -114,7 +114,7 @@ class Character:
             )
             time.sleep(1)
 
-    def possibly_activate_special_ability(self, chance, opponent):
+    def possibly_activate_special_ability(self, chance, human_opponent):
         """Depending on percent chance, possibly auto-activiate a special ability.
 
         Definitely meant for the non-human contender the moment.
@@ -122,7 +122,7 @@ class Character:
         Chance is hard-coded for this now because I am sad.
         """
         if not did_it_happen(chance):
-            return self, opponent
+            return self, human_opponent
 
         from special_abilities import SpecialAbility
 
@@ -131,9 +131,9 @@ class Character:
         ]
         if not abilities:
             # why am i doing this. what is life?
-            return self, opponent
+            return self, human_opponent
 
         ability = SpecialAbility(
-            player=self, opponent=opponent, effect=random.choice(abilities)
+            player=self, opponent=human_opponent, effect=random.choice(abilities)
         )
         return ability.perform()

--- a/characters/nora/special.json
+++ b/characters/nora/special.json
@@ -1,5 +1,5 @@
 {
-    "Become Norm!": {
+    "Shapeshift!": {
         "description": "At the cost of 1 life point, transform into Norm. His magic is a little different, but it might be a better fit against your opponent!",
         "effect": "change_to_norm"
     }

--- a/characters/winfield/special.json
+++ b/characters/winfield/special.json
@@ -1,0 +1,6 @@
+{
+    "Use the orbs of disorder for real": {
+        "description": "Inflict chaos on your opponent's magical ability by randomly swapping the hit values of their spells",
+        "effect": "orbs_of_disorderify"
+    }
+}

--- a/game.py
+++ b/game.py
@@ -142,16 +142,13 @@ class Game:
                 deny_func=self.player_turn,
             )
             ability = SpecialAbility(
-                player=self.player,
-                opponent=self.opponent,
-                effect=choice.effect
+                player=self.player, opponent=self.opponent, effect=choice.effect
             )
             # todo: return and reset potentially modified versions of
-            # both player and opponent? 
+            # both player and opponent?
             special_result = ability.perform()
             if isinstance(special_result, Character):
                 self.player = special_result
-
 
     def opponent_turn(self):
         self.opponent.possibly_taunt()
@@ -159,7 +156,7 @@ class Game:
         special_result = self.opponent.possibly_activate_special_ability(
             chance=OPPONENT_SPECIAL_ABILITY_CHANCE,
             # the opponent of the opponent is of course the player
-            opponent=self.player
+            opponent=self.player,
         )
         if isinstance(special_result, Character):
             self.opponent = special_result

--- a/game.py
+++ b/game.py
@@ -103,6 +103,7 @@ class Game:
             # might be better at fewer things.
             if not info["spells"]:
                 continue
+            # Rotate among the available spells for each dimension
             choice_key = f'{random.choice(info["spells"])} ({dimension})'
             choices[choice_key] = SpellChoice(dimension=dimension, hit=info["amount"])
 
@@ -144,22 +145,18 @@ class Game:
             ability = SpecialAbility(
                 player=self.player, opponent=self.opponent, effect=choice.effect
             )
-            # todo: return and reset potentially modified versions of
-            # both player and opponent?
-            special_result = ability.perform()
-            if isinstance(special_result, Character):
-                self.player = special_result
+            self.player, self.opponent = ability.perform()
 
     def opponent_turn(self):
         self.opponent.possibly_taunt()
 
-        special_result = self.opponent.possibly_activate_special_ability(
+        # the opponent of the opponent is of course the player, so keep that
+        # in mind when returning player, opponent result format
+        modified_opponent_as_player, modified_player_as_opponent = self.opponent.possibly_activate_special_ability(
             chance=OPPONENT_SPECIAL_ABILITY_CHANCE,
-            # the opponent of the opponent is of course the player
             opponent=self.player,
         )
-        if isinstance(special_result, Character):
-            self.opponent = special_result
+        self.opponent, self.player = modified_opponent_as_player, modified_player_as_opponent
 
         spell_info = self.opponent.magic_info["deals"]
         # Recall that not everyone can deal every kind, as a cost to being

--- a/game.py
+++ b/game.py
@@ -154,7 +154,7 @@ class Game:
         # in mind when returning player, opponent result format
         modified_opponent_as_player, modified_player_as_opponent = self.opponent.possibly_activate_special_ability(
             chance=OPPONENT_SPECIAL_ABILITY_CHANCE,
-            opponent=self.player,
+            human_opponent=self.player,
         )
         self.opponent, self.player = modified_opponent_as_player, modified_player_as_opponent
 

--- a/game_macros.py
+++ b/game_macros.py
@@ -9,6 +9,7 @@ OPPONENT_SPECIAL_ABILITY_CHANCE = 0.2
 
 SpellChoice = namedtuple("SpellChoice", ["dimension", "hit"])
 SpecialChoice = namedtuple("SpecialChoice", ["description", "effect"])
+SpecialEffect = namedtuple("SpecialEffect", ["affected_player", "affected_opponent"])
 
 
 def did_it_happen(chance=0.5):

--- a/game_macros.py
+++ b/game_macros.py
@@ -9,7 +9,6 @@ OPPONENT_SPECIAL_ABILITY_CHANCE = 0.2
 
 SpellChoice = namedtuple("SpellChoice", ["dimension", "hit"])
 SpecialChoice = namedtuple("SpecialChoice", ["description", "effect"])
-SpecialEffect = namedtuple("SpecialEffect", ["affected_player", "affected_opponent"])
 
 
 def did_it_happen(chance=0.5):

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -6,7 +6,7 @@ import time
 import upsidedown
 
 from character import Character
-from game_macros import did_it_happen, SpecialEffect
+from game_macros import did_it_happen
 
 
 class SpecialAbility:

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -9,7 +9,6 @@ from character import Character
 from game_macros import did_it_happen
 
 
-
 class SpecialAbility:
     # TODO: fix this class; it seems contrived
     def __init__(self, player, opponent, effect):
@@ -18,13 +17,17 @@ class SpecialAbility:
         self.effect_func = getattr(sys.modules[__name__], effect)
 
     def perform(self, **kwargs):
-        import pdb; pdb.set_trace()  
+        import pdb
+
+        pdb.set_trace()
         return self.effect_func(self.player, self.opponent, **kwargs)
+
 
 # Just a mess of special abilities to load from one spot. For now they
 # get associated to their characters via the spell choices, which
 # opens the potential for sharing (that or I am too lazy to just put
 # these into the character modules nicely)
+
 
 def change_to_norm(nora, *_, **__):
     # Circular imports are an unfortunate thing...

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -6,21 +6,18 @@ import time
 import upsidedown
 
 from character import Character
-from game_macros import did_it_happen
+from game_macros import did_it_happen, SpecialEffect
 
 
 class SpecialAbility:
-    # TODO: fix this class; it seems contrived
     def __init__(self, player, opponent, effect):
         self.player = player
         self.opponent = opponent
+        # gross
         self.effect_func = getattr(sys.modules[__name__], effect)
 
-    def perform(self, **kwargs):
-        import pdb
-
-        pdb.set_trace()
-        return self.effect_func(self.player, self.opponent, **kwargs)
+    def perform(self, **additional_options):
+        return self.effect_func(self.player, self.opponent, **additional_options)
 
 
 # Just a mess of special abilities to load from one spot. For now they
@@ -29,33 +26,33 @@ class SpecialAbility:
 # these into the character modules nicely)
 
 
-def change_to_norm(nora, *_, **__):
+def change_to_norm(player, opponent, **_):
     # Circular imports are an unfortunate thing...
     from game import CHARACTERS_DIR
 
-    nora.life -= 1
+    player.life -= 1
 
     norm_namepath = f"{CHARACTERS_DIR}/nora/norm"
     norm = Character(name="Norm", special_namepath=norm_namepath)
-    norm.life = nora.life
+    norm.life = player.life
 
-    print(f"{nora.name} becomes Norm!")
+    print(f"{player.name} becomes Norm!")
     time.sleep(1)
 
-    return norm
+    return norm, opponent
 
 
-def change_to_nora(norm, *_, **__):
-    norm.life -= 1
+def change_to_nora(player, opponent, **_):
+    player.life -= 1
 
     # Re-instantiate because why not. Only life changes.
     nora = Character(name="Nora")
-    nora.life = norm.life
+    nora.life = player.life
 
-    print(f"{norm.name} becomes Nora!")
+    print(f"{player.name} becomes Nora!")
     time.sleep(1)
 
-    return nora
+    return nora, opponent
 
 
 def _potion_life_effect():
@@ -93,7 +90,7 @@ def _print_potion_effect(character_name, effect):
     time.sleep(1)
 
 
-def potionify(player, *_, **__):
+def potionify(player, opponent, **_):
     effect = _potion_life_effect()
     player.life += effect
 
@@ -103,10 +100,10 @@ def potionify(player, *_, **__):
     drunkard._set_special_abilities(f"{drunkard.namepath}/drunk_special.json")
     _print_potion_effect(drunkard.name, effect)
 
-    return drunkard
+    return drunkard, opponent
 
 
-def attempt_sobering(player, *_, is_computer=False):
+def attempt_sobering(player, opponent, is_computer=False):
     """was it a good idea?"""
     if did_it_happen():
         # Restore defaults!
@@ -133,9 +130,9 @@ def attempt_sobering(player, *_, is_computer=False):
                 f"shortcut to sobriety. They lose 1 life point!"
             )
         time.sleep(1)
-        return player
+        return player, opponent
 
 
-def orbs_of_disorderify(player, opponent, **__):
+def orbs_of_disorderify(player, opponent, **_):
     print("coming soon! winfield's orbs need some maintenance...")
-    return player
+    return player, opponent

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -13,8 +13,7 @@ class SpecialAbility:
     def __init__(self, player, opponent, effect):
         self.player = player
         self.opponent = opponent
-        # gross
-        import pdb; pdb.set_trace()  
+        # literally just load them all from here for now
         self.effect_func = getattr(sys.modules[__name__], effect)
 
     def perform(self, **additional_options):
@@ -129,5 +128,13 @@ def attempt_sobering(player, opponent, is_computer=False):
 
 
 def orbs_of_disorderify(player, opponent, **_):
-    print("coming soon! winfield's orbs need some maintenance...")
+    """
+    Mix up the hit values of the opponent's spells.
+    """
+    deal_amounts = [dim['amount'] for dim in opponent.magic_info['deals'].values()]
+
+    for dimension_info in opponent.magic_info["deals"].values():
+        now_deals = deal_amounts.pop(random.randrange(len(deal_amounts)))
+        dimension_info["amount"] = now_deals
+
     return player, opponent

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -90,6 +90,7 @@ def potionify(player, opponent, **_):
 
     drunkard = Character(name=player.name)
     drunkard.life = player.life
+    # TODO: don't deepcopy
     drunkard.magic_info = _drunkify_spells(drunkard.magic_info)
     drunkard._set_special_abilities(f"{drunkard.namepath}/drunk_special.json")
     _print_potion_effect(drunkard.name, effect)

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -9,7 +9,7 @@ from character import Character
 from game_macros import did_it_happen, SpecialEffect
 
 
-class SpecialAbility:
+class DeprecatedSpecialAbility:
     def __init__(self, player, opponent, effect):
         self.player = player
         self.opponent = opponent
@@ -20,10 +20,31 @@ class SpecialAbility:
         return self.effect_func(self.player, self.opponent, **additional_options)
 
 
-# Just a mess of special abilities to load from one spot. For now they
-# get associated to their characters via the spell choices, which
-# opens the potential for sharing (that or I am too lazy to just put
-# these into the character modules nicely)
+class SpecialAbility:
+    def __init__(self, player, opponent):
+        self.player = player
+        self.opponent = opponent
+
+    def perform(self, **additional_options):
+        raise NotImplementedError
+
+
+class ChangeToNorm(SpecialAbility):
+    def perform(self, **_):
+        # TODO: is it even circular once moved
+        # Circular imports are an unfortunate thing...
+        from game import CHARACTERS_DIR
+
+        self.player.life -= 1
+
+        norm_namepath = f"{CHARACTERS_DIR}/nora/norm"
+        norm = Character(name="Norm", special_namepath=norm_namepath)
+        norm.life = self.player.life
+
+        print(f"{self.player.name} becomes Norm!")
+        time.sleep(1)
+
+        return norm, self.opponent
 
 
 def change_to_norm(player, opponent, **_):

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -92,7 +92,9 @@ def potionify(player, opponent, **_):
     drunkard.life = player.life
     # TODO: don't deepcopy
     drunkard.magic_info = _drunkify_spells(drunkard.magic_info)
-    drunkard._set_special_abilities(special_path=f"{drunkard.namepath}/drunk_special.json")
+    drunkard._set_special_abilities(
+        special_path=f"{drunkard.namepath}/drunk_special.json"
+    )
     _print_potion_effect(drunkard.name, effect)
 
     return drunkard, opponent
@@ -131,7 +133,7 @@ def orbs_of_disorderify(player, opponent, **_):
     """
     Mix up the hit values of the opponent's spells.
     """
-    deal_amounts = [dim['amount'] for dim in opponent.magic_info['deals'].values()]
+    deal_amounts = [dim["amount"] for dim in opponent.magic_info["deals"].values()]
 
     for dimension_info in opponent.magic_info["deals"].values():
         now_deals = deal_amounts.pop(random.randrange(len(deal_amounts)))

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -92,7 +92,7 @@ def potionify(player, opponent, **_):
     drunkard.life = player.life
     # TODO: don't deepcopy
     drunkard.magic_info = _drunkify_spells(drunkard.magic_info)
-    drunkard._set_special_abilities(f"{drunkard.namepath}/drunk_special.json")
+    drunkard._set_special_abilities(special_path=f"{drunkard.namepath}/drunk_special.json")
     _print_potion_effect(drunkard.name, effect)
 
     return drunkard, opponent
@@ -110,7 +110,6 @@ def attempt_sobering(player, opponent, is_computer=False):
         else:
             print(f"\n{player.name} has sobered up and gained 1 life point!")
         time.sleep(1)
-
         return sober, opponent
     else:
         player.life -= 1

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -111,7 +111,7 @@ def attempt_sobering(player, opponent, is_computer=False):
             print(f"\n{player.name} has sobered up and gained 1 life point!")
         time.sleep(1)
 
-        return sober
+        return sober, opponent
     else:
         player.life -= 1
         if not is_computer:

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -9,42 +9,16 @@ from character import Character
 from game_macros import did_it_happen, SpecialEffect
 
 
-class DeprecatedSpecialAbility:
+class SpecialAbility:
     def __init__(self, player, opponent, effect):
         self.player = player
         self.opponent = opponent
         # gross
+        import pdb; pdb.set_trace()  
         self.effect_func = getattr(sys.modules[__name__], effect)
 
     def perform(self, **additional_options):
         return self.effect_func(self.player, self.opponent, **additional_options)
-
-
-class SpecialAbility:
-    def __init__(self, player, opponent):
-        self.player = player
-        self.opponent = opponent
-
-    def perform(self, **additional_options):
-        raise NotImplementedError
-
-
-class ChangeToNorm(SpecialAbility):
-    def perform(self, **_):
-        # TODO: is it even circular once moved
-        # Circular imports are an unfortunate thing...
-        from game import CHARACTERS_DIR
-
-        self.player.life -= 1
-
-        norm_namepath = f"{CHARACTERS_DIR}/nora/norm"
-        norm = Character(name="Norm", special_namepath=norm_namepath)
-        norm.life = self.player.life
-
-        print(f"{self.player.name} becomes Norm!")
-        time.sleep(1)
-
-        return norm, self.opponent
 
 
 def change_to_norm(player, opponent, **_):


### PR DESCRIPTION
- bugfix such that sobering up message of Winston's drunk ability actually makes sense based on whether you or opponent says it
- enable special abilities to affect either player or opponent with slight refactor. Implement Winfield's Orbs of Disorder, which mix up opponent's spell numbers, as the first example of this
- more informative message about number of life dots left


![Screenshot 2023-07-16 184444](https://github.com/fialovy/magic_fight/assets/10673023/e8840d8a-d58c-4dc5-bd78-8bfada512db8)
