### PR TITLE
#22: countdown of affected turns

### DIFF
--- a/character.py
+++ b/character.py
@@ -17,6 +17,7 @@ class Character:
     bio: str  # a short description of the character
     ascii_art: str  # this game has ✨ advanced graphics ✨
     magic_info: CharacterMagicInfo
+    affected_by_character_turns_left: dict["Character", int]
     taunts: Optional[CharacterTaunts]
     reactions: Optional[CharacterReactions]
     special_abilities_info: dict[str, CharacterSpecialAbilitiesInfo]
@@ -25,6 +26,8 @@ class Character:
         self.life = GAME_LIFE
         self.name = name
         self.namepath = special_namepath or f"{CHARACTERS_DIR}/{name.lower()}"
+        # some sort of countdown...eventually
+        self.affected_by_character_turns_left = {}
 
         self._set_bio()
         self._set_ascii_art()
@@ -134,3 +137,15 @@ class Character:
                 f"{self.name} says: " f'{random.choice(self.reactions["reactions"])}\n'
             )
             time.sleep(1)
+
+    def reset(self, opponent_name: str, is_computer: bool = False) -> None:
+        # for now broad blind reset; later more specific how (and if) based
+        # on character and status of same affected areas from other characters
+        self._set_magic_info()
+        self._set_taunts()
+        self._set_reactions()
+
+        affected_phrase = f"{self.name} has" if is_computer else "You have"
+        affector_phrase = f"{opponent_name}'s" if is_computer else "your"
+        print(f"{affected_phrase} recovered from {affector_phrase} magical effect!")
+        time.sleep(1)

--- a/character.py
+++ b/character.py
@@ -146,6 +146,6 @@ class Character:
         self._set_reactions()
 
         affected_phrase = f"{self.name} has" if is_computer else "You have"
-        affector_phrase = f"{opponent_name}'s" if is_computer else "your"
+        affector_phrase = "your" if is_computer else f"{opponent_name}'s"
         print(f"{affected_phrase} recovered from {affector_phrase} magical effect!")
         time.sleep(1)

--- a/character.py
+++ b/character.py
@@ -26,8 +26,9 @@ class Character:
         self.life = GAME_LIFE
         self.name = name
         self.namepath = special_namepath or f"{CHARACTERS_DIR}/{name.lower()}"
-        # some sort of countdown...eventually
-        self.affected_by_character_turns_left = {}
+        self.affected_by_character_turns_left = (
+            {}
+        )  # countdown of turns left by character causing effect
 
         self._set_bio()
         self._set_ascii_art()

--- a/game.py
+++ b/game.py
@@ -84,7 +84,7 @@ class Game:
     ) -> Character:
         # if 0, do nothing
         # if 1, reset magic infos (e.g., if affected by Orbs of Disorder, regular magic is restored
-        # if > 1, decrement
+        # if >= 1, decrement
         # right now this is kinda silly because there is one opponent at a time,
         # and when that one opponent's effect wears off, 'everyone's' does
         # but who knows...maybe there will be a future

--- a/game.py
+++ b/game.py
@@ -192,12 +192,7 @@ class Game:
             self.player.print_life()
             self.opponent.print_life()
             time.sleep(1)
-            import pprint
 
-            pp = pprint.PrettyPrinter()
-            print("+++++++++++++++++ PLAYER STATUS:")
-            pp.pprint(self.player.magic_info)
-            print("++++++++++++++++++++++++++++++++++")
             self.player_turn()
             if self.opponent.life <= 0:
                 print(
@@ -206,10 +201,6 @@ class Game:
                 time.sleep(2)
                 return
 
-            # debug
-            print("+++++++++++++++++ OPPONENT STATUS:")
-            pp.pprint(self.opponent.magic_info)
-            print("++++++++++++++++++++++++++++++++++")
             self.opponent_turn()
             if self.player.life <= 0:
                 print(f"{self.opponent.name} has bested you. Game over.")

--- a/game.py
+++ b/game.py
@@ -85,23 +85,19 @@ class Game:
         # if 0, do nothing
         # if 1, reset magic infos (e.g., if affected by Orbs of Disorder, regular magic is restored
         # if > 1, decrement
-        # except this is sad because when one opponent's effect wears off, everyone's does
+        # right now this is kinda silly because there is one opponent at a time,
+        # and when that one opponent's effect wears off, 'everyone's' does
+        # but who knows...maybe there will be a future
         for character, turns_left in affected.affected_by_character_turns_left.items():
             if turns_left == 0:
                 continue
 
             if turns_left == 1:
-                # reset = Character(
-                #    name=affected.name,  # namepath=affected.namepath does this work for the shapeshifter??
-                # )
-                # reset.life = affected.life
-                # affected = reset
                 affected.reset(opponent_name=character.name, is_computer=is_computer)
-                continue  # affected_by_character_turns_left has also just reset TODO: for THIS CHARACTER?
 
             affected.affected_by_character_turns_left[character] -= 1
 
-        return affected  # TODO: does need anymore?
+        return affected
 
     def player_turn(self) -> None:
         spell_infos = self._construct_player_spell_choices()

--- a/game_macros.py
+++ b/game_macros.py
@@ -13,6 +13,9 @@ from typing import Any, Callable, Final, Literal, Optional, TypedDict, Union
 CHARACTERS_DIR: Final = "characters"
 GAME_LIFE: Final = 15
 OPPONENT_SPECIAL_ABILITY_CHANCE: Final = 0.2
+DEFAULT_SPECIAL_ABILITY_TURNS = (
+    3  # number of turns a special ability lasts by default, if it affects any state
+)
 
 
 ## Types

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -12,7 +12,8 @@ except ImportError:
     NO_UPSIDEDOWN = True
 
 from character import Character, CharacterMagicInfo
-from game_macros import CHARACTERS_DIR, did_it_happen
+from game_macros import (CHARACTERS_DIR, DEFAULT_SPECIAL_ABILITY_TURNS,
+                         did_it_happen)
 
 
 class SpecialAbility:
@@ -170,6 +171,7 @@ def orbs_of_disorderify(
         now_deals = deal_amounts.pop(random.randrange(len(deal_amounts)))
         dimension_info["amount"] = now_deals
 
+    opponent.affected_by_character_turns_left[player] = DEFAULT_SPECIAL_ABILITY_TURNS
     if is_computer:
         print(
             f"{player.name} has used the Orbs of Disorder to randomly "

--- a/special_abilities.py
+++ b/special_abilities.py
@@ -81,7 +81,7 @@ def _potion_life_effect() -> int:
 
 def _drunkify_spells(magic_info: CharacterMagicInfo) -> CharacterMagicInfo:
     """Flip the given spell descriptions upside down, because we are drunk."""
-    drunken_magic = copy.deepcopy(magic_info)
+    drunken_magic = copy.deepcopy(magic_info)  # it's not THAT big
 
     for dimension_info in drunken_magic["deals"].values():
         if not NO_UPSIDEDOWN:
@@ -118,7 +118,6 @@ def potionify(
 
     drunkard = Character(name=player.name)
     drunkard.life = player.life
-    # TODO: don't deepcopy
     drunkard.magic_info = _drunkify_spells(drunkard.magic_info)
     drunkard._set_special_abilities(
         special_path=f"{drunkard.namepath}/drunk_special.json"


### PR DESCRIPTION
`Character.affected_by_character_turns_left` is a dict keyed by character with values being number of turns left that their special ability affects you (or others a.k.a. you affects the computer opponent).

It ain't much now, because:

1) Only Winfield's orb ability actually alters other people's magic 🟡
2) Reset resets everything
3) I don't mind 2) because you only can play one person at a time right now 